### PR TITLE
feat: Add multiple image generation API endpoints

### DIFF
--- a/api_calls-refactor.js
+++ b/api_calls-refactor.js
@@ -252,6 +252,147 @@ async function callImageGenerationAPI(promptToSend, endpointConfig, runIdentifie
                 if (typeof pollComfyHistory === 'function') pollComfyHistory(result.promptId, serverAddress, endpointConfig.id, endpointConfig.name, runIdentifier);
                 return result;
             }
+            case 'fal_ai': {
+                if (!endpointConfig.apiKey) throw new Error("API Key for fal.ai is missing.");
+                if (!endpointConfig.model) throw new Error("Model for fal.ai is missing.");
+                apiUrl = `https://fal.run/${endpointConfig.model}`;
+                requestHeaders['Authorization'] = `Key ${endpointConfig.apiKey}`;
+
+                const falSeed = (typeof generateRandomSeed === 'function') ? generateRandomSeed() : Date.now();
+                requestBody = { prompt: promptToSend, seed: falSeed };
+
+                const response = await fetch(apiUrl, { method, headers: requestHeaders, body: JSON.stringify(requestBody) });
+                if (!response.ok) {
+                    let e = response.statusText;
+                    try { const j = await response.json(); e = j.detail || j.error || JSON.stringify(j); } catch (_) {}
+                    throw new Error(`fal.ai Error (${response.status}): ${e}`);
+                }
+                const responseData = await response.json();
+                if (responseData.images?.[0]?.url) {
+                    result.imageUrl = responseData.images[0].url;
+                    result.message = "fal.ai OK.";
+                } else if (responseData.images?.[0]) {
+                     const img = responseData.images[0];
+                     if (img.url) result.imageUrl = img.url;
+                     else result.imageData = `data:image/jpeg;base64,${img}`;
+                } else {
+                     throw new Error("fal.ai response missing standard image format.");
+                }
+                result.status = 'success';
+                if (typeof updateImageResultItem === 'function') updateImageResultItem(endpointConfig.id, endpointConfig.name, result, runIdentifier);
+                return result;
+            }
+
+            case 'openrouter': {
+                if (!endpointConfig.apiKey) throw new Error("API Key for OpenRouter is missing.");
+                if (!endpointConfig.model) throw new Error("Please select an OpenRouter model first.");
+                apiUrl = 'https://openrouter.ai/api/v1/chat/completions';
+                requestHeaders['Authorization'] = `Bearer ${endpointConfig.apiKey}`;
+
+                requestBody = {
+                    model: endpointConfig.model,
+                    messages: [
+                        { role: 'user', content: promptToSend }
+                    ],
+                    modalities: ['image']
+                };
+
+                const response = await fetch(apiUrl, { method, headers: requestHeaders, body: JSON.stringify(requestBody) });
+                if (!response.ok) {
+                    let e = response.statusText;
+                    try { const j = await response.json(); e = j.error?.message || JSON.stringify(j); } catch (_) {}
+                    throw new Error(`OpenRouter Error (${response.status}): ${e}`);
+                }
+                const responseData = await response.json();
+                if (responseData.choices?.[0]?.message?.images?.[0]) {
+                     const imgObj = responseData.choices[0].message.images[0];
+                     if (imgObj.image_url?.url) {
+                         if (imgObj.image_url.url.startsWith('data:image')) {
+                             result.imageData = imgObj.image_url.url;
+                         } else {
+                             result.imageUrl = imgObj.image_url.url;
+                         }
+                         result.message = "OpenRouter OK.";
+                     } else {
+                         throw new Error("OpenRouter image missing URL/data.");
+                     }
+                } else {
+                    throw new Error("OpenRouter JSON missing images array in response message.");
+                }
+                result.status = 'success';
+                if (typeof updateImageResultItem === 'function') updateImageResultItem(endpointConfig.id, endpointConfig.name, result, runIdentifier);
+                return result;
+            }
+
+            case 'google_nano_banana': {
+                if (!endpointConfig.apiKey) throw new Error("API Key for Google Nano Banana is missing.");
+                apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${endpointConfig.model}:generateContent?key=${endpointConfig.apiKey}`;
+
+                requestBody = {
+                    contents: [
+                        { parts: [{ text: promptToSend }] }
+                    ],
+                    generationConfig: {
+                        responseModalities: ["IMAGE"]
+                    }
+                };
+
+                const response = await fetch(apiUrl, { method, headers: requestHeaders, body: JSON.stringify(requestBody) });
+                if (!response.ok) {
+                    let e = response.statusText;
+                    try { const j = await response.json(); e = j.error?.message || JSON.stringify(j); } catch (_) {}
+                    throw new Error(`Google Nano Banana Error (${response.status}): ${e}`);
+                }
+                const responseData = await response.json();
+                const parts = responseData.candidates?.[0]?.content?.parts;
+                if (!parts) throw new Error("Google API response missing parts.");
+
+                let foundImage = false;
+                for (const part of parts) {
+                    if (part.inlineData?.data) {
+                        const mime = part.inlineData.mimeType || 'image/jpeg';
+                        result.imageData = `data:${mime};base64,${part.inlineData.data}`;
+                        result.message = "Google Nano Banana OK.";
+                        foundImage = true;
+                        break;
+                    }
+                }
+
+                if (!foundImage) throw new Error("Google Nano Banana JSON missing inlineData.data.");
+                result.status = 'success';
+                if (typeof updateImageResultItem === 'function') updateImageResultItem(endpointConfig.id, endpointConfig.name, result, runIdentifier);
+                return result;
+            }
+
+            case 'huggingface': {
+                if (!endpointConfig.apiKey) throw new Error("API Token for Hugging Face is missing.");
+                if (!endpointConfig.model) throw new Error("Model for Hugging Face is missing.");
+                apiUrl = `https://api-inference.huggingface.co/models/${endpointConfig.model}`;
+                requestHeaders['Authorization'] = `Bearer ${endpointConfig.apiKey}`;
+
+                requestBody = { inputs: promptToSend };
+
+                const response = await fetch(apiUrl, { method, headers: requestHeaders, body: JSON.stringify(requestBody) });
+                if (!response.ok) {
+                    let e = response.statusText;
+                    try { const j = await response.json(); e = j.error || JSON.stringify(j); } catch (_) {}
+                    throw new Error(`Hugging Face Error (${response.status}): ${e}`);
+                }
+
+                const contentType = response.headers.get("content-type");
+                if (contentType && contentType.startsWith("image/")) {
+                    const blob = await response.blob();
+                    result.imageData = (typeof blobToBase64 === 'function') ? await blobToBase64(blob) : null;
+                    result.message = "Hugging Face OK.";
+                } else {
+                    throw new Error(`Hugging Face returned non-image response (${contentType}).`);
+                }
+
+                result.status = 'success';
+                if (typeof updateImageResultItem === 'function') updateImageResultItem(endpointConfig.id, endpointConfig.name, result, runIdentifier);
+                return result;
+            }
+
             case 'custom_image': {
                 if (!apiUrl) throw new Error("Custom Image Endpoint URL is missing.");
                 const customSeedToUse = (typeof generateRandomSeed === 'function') ? generateRandomSeed() : Date.now();

--- a/index-refactor-v1.html
+++ b/index-refactor-v1.html
@@ -328,7 +328,77 @@
                                 </div>
                             </div>
                         </div>
-                        
+
+                        <div class="endpoint-option">
+                            <div class="endpoint-header">
+                                <input type="checkbox" id="img-fal-ai" value="fal_ai">
+                                <label for="img-fal-ai">fal.ai <small>(<a href="https://fal.ai/dashboard/keys" target="_blank" style="color:var(--primary);text-decoration:underline;">Get Key</a> - Includes free trial credits)</small></label>
+                            </div>
+                            <div class="endpoint-config">
+                                <div class="form-group">
+                                    <label for="fal-ai-model">Model</label>
+                                    <input type="text" id="fal-ai-model" class="form-input" value="fal-ai/flux/dev">
+                                </div>
+                                <div class="form-group">
+                                    <label for="fal-ai-key">API Key</label>
+                                    <input type="password" id="fal-ai-key" class="form-input" placeholder="Enter fal.ai key">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="endpoint-option">
+                            <div class="endpoint-header">
+                                <input type="checkbox" id="img-openrouter" value="openrouter">
+                                <label for="img-openrouter">OpenRouter <small>(<a href="https://openrouter.ai/keys" target="_blank" style="color:var(--primary);text-decoration:underline;">Get Key</a> - Free models & trial available)</small></label>
+                            </div>
+                            <div class="endpoint-config">
+                                <div class="form-group">
+                                    <label for="openrouter-key">API Key</label>
+                                    <input type="password" id="openrouter-key" class="form-input" placeholder="Enter OpenRouter API key">
+                                    <button type="button" id="openrouter-fetch-models-btn" class="secondary-button" style="margin-top: 0.5rem; width: fit-content; padding: 0.4rem 0.8rem; font-size: 0.85em;">
+                                        <i class="fas fa-sync"></i>
+                                        <span>Fetch Models</span>
+                                    </button>
+                                </div>
+                                <div class="form-group">
+                                    <label for="openrouter-model-select">Model</label>
+                                    <select id="openrouter-model-select" class="form-select">
+                                        <option value="">-- Fetch models first --</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="endpoint-option">
+                            <div class="endpoint-header">
+                                <input type="checkbox" id="img-google-nano-banana" value="google_nano_banana">
+                                <label for="img-google-nano-banana">Google Nano Banana <small>(<a href="https://aistudio.google.com/app/apikey" target="_blank" style="color:var(--primary);text-decoration:underline;">Get Key</a> - Generous free tier)</small></label>
+                            </div>
+                            <div class="endpoint-config">
+                                <div class="form-group">
+                                    <label for="google-nano-banana-key">API Key</label>
+                                    <input type="password" id="google-nano-banana-key" class="form-input" placeholder="Enter Gemini API key">
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="endpoint-option">
+                            <div class="endpoint-header">
+                                <input type="checkbox" id="img-huggingface" value="huggingface">
+                                <label for="img-huggingface">Hugging Face <small>(<a href="https://huggingface.co/settings/tokens" target="_blank" style="color:var(--primary);text-decoration:underline;">Get Token</a> - Free tier available)</small></label>
+                            </div>
+                            <div class="endpoint-config">
+                                <div class="form-group">
+                                    <label for="huggingface-model">Model</label>
+                                    <input type="text" id="huggingface-model" class="form-input" value="black-forest-labs/FLUX.1-dev">
+                                </div>
+                                <div class="form-group">
+                                    <label for="huggingface-key">API Token</label>
+                                    <input type="password" id="huggingface-key" class="form-input" placeholder="Enter Hugging Face Token (hf_...)">
+                                </div>
+                            </div>
+                        </div>
+
                         <div id="custom-endpoints-list"></div>
                         
                         <button type="button" id="add-custom-endpoint-btn" class="secondary-button">

--- a/state_management-refactor.js
+++ b/state_management-refactor.js
@@ -342,6 +342,58 @@ function getSelectedImageEndpoints() {
             requiresKey: false
         });
     }
+
+    const falAiCheckbox = imageEndpointsContainer.querySelector('#img-fal-ai:checked');
+    if (falAiCheckbox) {
+        const falAiKey = document.getElementById('fal-ai-key')?.value?.trim();
+        const falAiModel = document.getElementById('fal-ai-model')?.value?.trim() || 'fal-ai/flux/dev';
+        endpoints.push({
+            id: falAiCheckbox.id, value: falAiCheckbox.value,
+            name: 'fal.ai',
+            model: falAiModel,
+            apiKey: falAiKey,
+            requiresKey: true
+        });
+    }
+
+    const openrouterCheckbox = imageEndpointsContainer.querySelector('#img-openrouter:checked');
+    if (openrouterCheckbox) {
+        const openrouterKey = document.getElementById('openrouter-key')?.value?.trim();
+        const openrouterModel = document.getElementById('openrouter-model-select')?.value?.trim();
+        endpoints.push({
+            id: openrouterCheckbox.id, value: openrouterCheckbox.value,
+            name: 'OpenRouter',
+            model: openrouterModel,
+            apiKey: openrouterKey,
+            requiresKey: true
+        });
+    }
+
+    const googleNanoBananaCheckbox = imageEndpointsContainer.querySelector('#img-google-nano-banana:checked');
+    if (googleNanoBananaCheckbox) {
+        const googleKey = document.getElementById('google-nano-banana-key')?.value?.trim();
+        endpoints.push({
+            id: googleNanoBananaCheckbox.id, value: googleNanoBananaCheckbox.value,
+            name: 'Google Nano Banana',
+            model: 'gemini-3.1-flash-image-preview',
+            apiKey: googleKey,
+            requiresKey: true
+        });
+    }
+
+    const huggingfaceCheckbox = imageEndpointsContainer.querySelector('#img-huggingface:checked');
+    if (huggingfaceCheckbox) {
+        const hfKey = document.getElementById('huggingface-key')?.value?.trim();
+        const hfModel = document.getElementById('huggingface-model')?.value?.trim() || 'black-forest-labs/FLUX.1-dev';
+        endpoints.push({
+            id: huggingfaceCheckbox.id, value: huggingfaceCheckbox.value,
+            name: 'Hugging Face',
+            model: hfModel,
+            apiKey: hfKey,
+            requiresKey: true
+        });
+    }
+
     const customCheckboxes = customEndpointsList.querySelectorAll('input[type="checkbox"]:checked');
     customCheckboxes.forEach(checkbox => {
         const inputId = checkbox.dataset.inputId;

--- a/ui_setup-refactor-v1.js
+++ b/ui_setup-refactor-v1.js
@@ -294,6 +294,59 @@ function setupCustomEndpoints() {
     addButton.addEventListener('click', () => {
         addCustomEndpoint();
     });
+
+    const openrouterFetchBtn = document.getElementById('openrouter-fetch-models-btn');
+    const openrouterModelSelect = document.getElementById('openrouter-model-select');
+    const openrouterKeyInput = document.getElementById('openrouter-key');
+
+    if (openrouterFetchBtn && openrouterModelSelect) {
+        openrouterFetchBtn.addEventListener('click', async () => {
+            const apiKey = openrouterKeyInput ? openrouterKeyInput.value.trim() : '';
+            openrouterModelSelect.innerHTML = '<option value="">Fetching models...</option>';
+            openrouterFetchBtn.disabled = true;
+
+            try {
+                const headers = {};
+                if (apiKey) {
+                    headers['Authorization'] = `Bearer ${apiKey}`;
+                }
+                const response = await fetch('https://openrouter.ai/api/v1/models', { headers });
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch models: ${response.statusText}`);
+                }
+                const data = await response.json();
+
+                // Filter models that support image generation
+                const imageModels = data.data.filter(model => {
+                    const arch = model.architecture;
+                    if (!arch) return false;
+                    const outputModalities = arch.output_modalities || [];
+                    const modality = arch.modality || '';
+                    return outputModalities.includes('image') || modality.includes('image');
+                });
+
+                // Sort models alphabetically by name
+                imageModels.sort((a, b) => a.name.localeCompare(b.name));
+
+                openrouterModelSelect.innerHTML = '';
+                if (imageModels.length === 0) {
+                     openrouterModelSelect.innerHTML = '<option value="">No image models found</option>';
+                } else {
+                    imageModels.forEach(model => {
+                        const option = document.createElement('option');
+                        option.value = model.id;
+                        option.textContent = model.name;
+                        openrouterModelSelect.appendChild(option);
+                    });
+                }
+            } catch (error) {
+                console.error("Error fetching OpenRouter models:", error);
+                openrouterModelSelect.innerHTML = '<option value="">Error fetching models</option>';
+            } finally {
+                openrouterFetchBtn.disabled = false;
+            }
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
Adds support for multiple external image generation services (fal.ai, OpenRouter, Google Nano Banana, and Hugging Face). Users can now select any combination of these services alongside Local ComfyUI, provide their API keys, and generate images concurrently from a single prompt. OpenRouter models that support image generation can be dynamically fetched and selected. The UI has been updated to provide helpful links for users to obtain their API keys.

---
*PR created automatically by Jules for task [5412197276796723493](https://jules.google.com/task/5412197276796723493) started by @aaaronmiller*